### PR TITLE
Debug/ios regulations

### DIFF
--- a/prisma/migrations/20250524070808_make_birthday_nullable/migration.sql
+++ b/prisma/migrations/20250524070808_make_birthday_nullable/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "User_name_birthday_key";
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "lastActiveAt" TIMESTAMP(3),
+ADD COLUMN     "notificationEnabled" BOOLEAN NOT NULL DEFAULT true,
+ALTER COLUMN "birthday" DROP NOT NULL;
+
+-- CreateTable
+CREATE TABLE "Notification" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" INTEGER NOT NULL,
+    "message" TEXT NOT NULL,
+    "isRead" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_name_key" ON "User"("name");
+
+-- AddForeignKey
+ALTER TABLE "Notification" ADD CONSTRAINT "Notification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,14 +11,14 @@ model User {
   id        Int      @id @default(autoincrement())
   createdAt DateTime @default(now())
   name      String
-  birthday  String
+  birthday  String?
   weight    Int
   colas     Cola[]
   notificationEnabled  Boolean    @default(true)
   lastActiveAt      DateTime?
   notifications   Notification[]
 
-  @@unique([name,birthday])
+  @@unique([name])
 }
 
 model Cola {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -8,16 +8,15 @@ const prisma = new PrismaClient();
 dotenv.config();
 
 router.post("/login", (async (req: Request, res: Response) => {
-  const { name, birthday } = req.body;
+  const { name} = req.body;
 
-  if (!name || !birthday) {
+  if (!name) {
     return res.status(400).json({ message: "Missing required fields" });
   }
 
   const user = await prisma.user.findFirst({
     where: {
       name,
-      birthday,
     },
   });
 


### PR DESCRIPTION
# 🚀 Pull Request

## Summary  
Refactored user schema and login flow to comply with iOS App Store guidelines by removing the requirement for user birthday.

---

## Changes  
- Made birthday field in User model nullable in schema.prisma
- Removed birthday requirement from user creation validation logic
- Updated login endpoint to authenticate with name only (no longer requires birthday)
- Adjusted @@unique([name, birthday]) constraint to @@unique([name])
- Created and applied Prisma migration to reflect these schema changes

---

## Why  
- Apple rejected the app due to violating [Guideline 5.1.1 - Privacy - Data Collection and Storage]
- Apps are not allowed to require unnecessary personal information like birthdates unless it’s essential to functionality
- This PR ensures user signup and login do not require birthday input

---

## Test Steps  
None
